### PR TITLE
Change Dockerfile user to non-root

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,2 +1,3 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY LICENSE /licenses/LICENSE
+USER 1001


### PR DESCRIPTION
This is required to fix a test failure in the `ecosystem-cert-preflight-checks` task.