### PR TITLE
Change renovate scheduling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "tekton": {
-    "includePaths": ["pipelines/**"]
+    "includePaths": ["pipelines/**"],
+    "schedule": ["after 5am"]
   }
 }


### PR DESCRIPTION
The current default from [konflux-ci](https://github.com/konflux-ci/mintmaker/blob/71330cae849a65cc36a1ab5436f734f7bc0e2e60/config/renovate/renovate.json#L100C8-L100C29) is set to `after 5am on saturday`. I need the pipelines to be updated more often to confirm that everything works as intended with this repo. Might revert this commit later...