### PR TITLE
Align rpms-signature-scan with the default definition from Konflux

### DIFF
--- a/pipelines/build-pipeline.yaml
+++ b/pipelines/build-pipeline.yaml
@@ -95,7 +95,7 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
-  - default: [ ]
+  - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
@@ -228,23 +228,6 @@ spec:
     workspaces:
     - name: source
       workspace: workspace
-  - name: rpms-signature-scan
-    params:
-    - name: image-digest
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-container.results.IMAGE_URL)
-    runAfter:
-    - build-container
-    taskRef:
-      params:
-      - name: name
-        value: rpms-signature-scan
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:60da26522b733e0375ebe996abf4b3b7c41720ae2858f6332945da3b1a9fd87d
-      - name: kind
-        value: task
-      resolver: bundles
   - name: build-image-index
     params:
     - name: IMAGE
@@ -451,6 +434,28 @@ spec:
     workspaces:
     - name: workspace
       workspace: workspace
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: rpms-signature-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:60da26522b733e0375ebe996abf4b3b7c41720ae2858f6332945da3b1a9fd87d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
   workspaces:
   - name: workspace
   - name: git-auth


### PR DESCRIPTION
The `rpms-signature-scan` task provided by Konflux on custom pipeline initialization was slightly different from the one we had in `build-pipeline.yaml`. This PR fixes that.