### PR TITLE
Revert "Change renovate scheduling (#10)"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "tekton": {
-    "includePaths": ["pipelines/**"],
-    "schedule": ["after 5am"]
+    "includePaths": ["pipelines/**"]
   }
 }


### PR DESCRIPTION
The Konflux bot successfully updated `pipelines/build-pipeline.yaml`. There's no need anymore for custom scheduling.