### PR TITLE
Add coverity, sast-shell and sast-unicode checks

### DIFF
--- a/pipelines/build-pipeline.yaml
+++ b/pipelines/build-pipeline.yaml
@@ -395,6 +395,108 @@ spec:
       operator: in
       values:
       - "false"
+  - name: sast-coverity-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-container.results.IMAGE_URL)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      params:
+      - name: name
+        value: sast-coverity-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.1@sha256:5331fdc503f50afa731a133936f638ed15b06a0ece4217659e210d90d04274d7
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: coverity-availability-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-container.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: coverity-availability-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.1@sha256:dfe1150a94c7464c4a1e0b5a2bfdab4c9c97f51a992f8a479a43acc64ffcbf73
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: sast-shell-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:2de060c734b4a0c804525f6ff57d4a5e4a380b7e1475676582282563202f8014
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: sast-unicode-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.1@sha256:f2fb1a902f1a33119e89333fd326d406ba595f384a80987ca51ad46777e22b25
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
   - name: apply-tags
     params:
     - name: IMAGE


### PR DESCRIPTION
This PR adds checks that are provided by Konflux on a pipeline definition initialization but were missing in `pipelines/build-pipeline.yaml`.