### PR TITLE
Support hermetic builds in docker-build-oci-ta.yaml and docker-build.yaml

### DIFF
--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -59,6 +59,10 @@ spec:
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
+  - default: "false"
+    description: Build dependencies with package managers to be prefetched by Cachi2
+    name: prefetch-dev-package-managers
+    type: string
   - default: ""
     description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
@@ -148,6 +152,8 @@ spec:
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
+    - name: dev-package-managers
+      value: $(params.prefetch-dev-package-managers)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -81,6 +81,10 @@ spec:
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
+  - default: "false"
+    description: Build dependencies with package managers to be prefetched by Cachi2
+    name: prefetch-dev-package-managers
+    type: string
   - default: ""
     description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
@@ -162,6 +166,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: dev-package-managers
+      value: $(params.prefetch-dev-package-managers)
     runAfter:
     - clone-repository
     taskRef:


### PR DESCRIPTION
* Enable parameter dev-package-managers needed for hermetic builds

You can see this parameter called out in the docs here:
https://konflux-ci.dev/docs/building/prefetching-dependencies/