### PR TITLE
fix: computeResources are a taskSpec definition, not a steps one

### DIFF
--- a/pipelines/platform-ui/docker-build-run-unit-tests.yaml
+++ b/pipelines/platform-ui/docker-build-run-unit-tests.yaml
@@ -652,6 +652,13 @@ spec:
         - mountPath: /var/workdir
           name: workdir
           readOnly: false
+      computeResources:
+        requests:
+          memory: $(params.unit-tests-memory-request)
+          cpu: $(params.unit-tests-cpu-request)
+        limits:
+          memory: $(params.unit-tests-memory-limit)
+          cpu: $(params.unit-tests-cpu-limit)
       sidecars:
       steps:
       - name: use-trusted-artifact
@@ -662,13 +669,6 @@ spec:
       - image: registry.access.redhat.com/ubi8/nodejs-18
         workingDir: /var/workdir
         name: unit-tests
-        computeResources:
-          requests:
-            memory: $(params.unit-tests-memory-request)
-            cpu: $(params.unit-tests-cpu-request)
-          limits:
-            memory: $(params.unit-tests-memory-limit)
-            cpu: $(params.unit-tests-cpu-limit)
         securityContext:
           runAsUser: 0
         script: $(params.unit-tests-script)


### PR DESCRIPTION
Working on https://github.com/RedHatInsights/insights-rbac-ui/pull/1860 I noticed that regardless of the memory option passed to the pipeline I was getting OOM errors. Reading the documentation I learnt that the computeResources block is a task level definition, not a steps one. This moves it to the right place.