### PR TITLE
chore: remove obsolete computeResources definition from docker-build-run-unit-tests pipeline

### DIFF
--- a/pipelines/platform-ui/docker-build-run-unit-tests.yaml
+++ b/pipelines/platform-ui/docker-build-run-unit-tests.yaml
@@ -108,23 +108,6 @@ spec:
   - description: Script run while executing the run-unit-tests custom task
     name: unit-tests-script
     type: string
-  # New parameters for unit test resources
-  - description: Memory request for the unit tests task
-    name: unit-tests-memory-request
-    type: string
-    default: "4Gi"
-  - description: Memory limit for the unit tests task
-    name: unit-tests-memory-limit
-    type: string
-    default: "4Gi"
-  - description: CPU request for the unit tests task
-    name: unit-tests-cpu-request
-    type: string
-    default: "2000m"
-  - description: CPU limit for the unit tests task
-    name: unit-tests-cpu-limit
-    type: string
-    default: "2000m"
   results:
   - description: ""
     name: IMAGE_URL
@@ -652,13 +635,6 @@ spec:
         - mountPath: /var/workdir
           name: workdir
           readOnly: false
-      computeResources:
-        requests:
-          memory: $(params.unit-tests-memory-request)
-          cpu: $(params.unit-tests-cpu-request)
-        limits:
-          memory: $(params.unit-tests-memory-limit)
-          cpu: $(params.unit-tests-cpu-limit)
       sidecars:
       steps:
       - name: use-trusted-artifact


### PR DESCRIPTION
# what

remove the `computeResources` definition, as well as the custom params which serve it (i.e. `unit-tests-memory-request`, `unit-tests-cpu-request`, `unit-tests-memory-limit`, `unit-tests-cpu-limit`), as obsolete.


# why

apparently, `computeResources` can only be applied in `PipelineRuns`, but not in `Pipelines`.

see:

- [specifying task level compute-resources](https://tekton.dev/docs/pipelines/pipelineruns/#specifying-task-level-computeresources) on tekton.dev docs
- [task level compute-resources configuration](https://github.com/tektoncd/pipeline/blob/main/docs/compute-resources.md#task-level-compute-resources-configuration) on tektoncd repo docs


# implications

- any pipeline-run configs consuming this pipeline should delete the obsolete params, in case they passed any (example usage: [insights-rbac-ui](https://github.com/RedHatInsights/insights-rbac-ui/blob/master/.tekton/insights-rbac-ui-pull-request.yaml#L40-L43))
- in case consumers want to control compute-resources, they can declare `taskRunSpecs`, like so:
  ```
  spec:
    # ...
    pipelineRef:
      name: docker-build
    # ...
    taskRunSpecs:
      - pipelineTaskName: run-unit-tests
        stepSpecs:
          - name: unit-tests
            computeResources:
              requests:
                memory: "8Gi"
              limits:
                memory: "8Gi"
  ```