### PR TITLE
feat: allow passing a buildah secret to docker-build-run-unit-tests

### DIFF
--- a/pipelines/platform-ui/docker-build-run-unit-tests.yaml
+++ b/pipelines/platform-ui/docker-build-run-unit-tests.yaml
@@ -51,10 +51,10 @@ spec:
     - name: workspace
       workspace: workspace
   params:
-  - description: Add a secret to the container build
+  - default: ""
+    description: Add a secret to the container build
     name: additional-secret
     type: string
-    default: ""
   - description: Source Repository URL
     name: git-url
     type: string

--- a/pipelines/platform-ui/docker-build-run-unit-tests.yaml
+++ b/pipelines/platform-ui/docker-build-run-unit-tests.yaml
@@ -51,6 +51,10 @@ spec:
     - name: workspace
       workspace: workspace
   params:
+  - description: Add a secret to the container build
+    name: additional-secret
+    type: string
+    default: ""
   - description: Source Repository URL
     name: git-url
     type: string
@@ -203,6 +207,8 @@ spec:
       workspace: netrc
   - name: build-container
     params:
+    - name: ADDITIONAL_SECRET
+      value: $(params.additional-secret)
     - name: IMAGE
       value: $(params.output-image)
     - name: DOCKERFILE


### PR DESCRIPTION
exposes the buildah `ADDITIONAL_SECRET` [param][2] as a pipeline parameter, to allow passing in build secrets.

incentive: pass in a glitchtip-token to an environment variable, like we currently do in jenkins.

[recommended][1] in konflux-users forum.


[1]: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1757967289139369
[2]: https://github.com/konflux-ci/build-definitions/tree/main/task/buildah-oci-ta/0.4#parameters