### PR TITLE
feat(secrets): allow passing additonal secrets to build

### DIFF
--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -43,7 +43,7 @@ spec:
     description: Path to the Dockerfile inside the context specified by parameter path-context
     name: dockerfile
     type: string
-  - default: sentry-auth
+  - default: build-container-additional-secret
     description: Name of secret in Konflux
     name: build-container-additional-secret
     type: string

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -43,6 +43,10 @@ spec:
     description: Path to the Dockerfile inside the context specified by parameter path-context
     name: dockerfile
     type: string
+  - default: sentry-auth
+    description: Name of secret in Konflux
+    name: build-secrets
+    type: string
   - default: "false"
     description: Force rebuild image
     name: rebuild
@@ -214,7 +218,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       #This additional secret is to access the konflux-UI sentry-auth secret :  https://konflux-ci.dev/docs/building/creating-secrets/#referencing-secrets-in-a-containerfile
     - name: ADDITIONAL_SECRET
-      value: sentry-auth
+      value: $(params.build-secrets)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -45,7 +45,7 @@ spec:
     type: string
   - default: sentry-auth
     description: Name of secret in Konflux
-    name: build-secrets
+    name: build-container-additional-secret
     type: string
   - default: "false"
     description: Force rebuild image

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -218,7 +218,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       #This additional secret is to access the konflux-UI sentry-auth secret :  https://konflux-ci.dev/docs/building/creating-secrets/#referencing-secrets-in-a-containerfile
     - name: ADDITIONAL_SECRET
-      value: $(params.build-secrets)
+      value: $(params.build-container-additional-secret)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -219,7 +219,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      #This additional secret is to access the konflux-UI sentry-auth secret :  https://konflux-ci.dev/docs/building/creating-secrets/#referencing-secrets-in-a-containerfile
     - name: ADDITIONAL_SECRET
       value: $(params.build-container-additional-secret)
     runAfter:

--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -44,7 +44,7 @@ spec:
     name: dockerfile
     type: string
   - default: build-container-additional-secret
-    description: Name of secret in Konflux
+    description: Name of a Konflux-managed secret that will be mounted and made available to the container build process. See https://konflux-ci.dev/docs/building/creating-secrets/#referencing-secrets-in-a-containerfile
     name: build-container-additional-secret
     type: string
   - default: "false"


### PR DESCRIPTION
### Description

This PR allows passing build secrets as tekton param so applications can name it however they want. At the same time we are not breaking any sentry-auth users because the default value is set to `sentry-auth`