### PR TITLE
fix(buildarg): ReAdd build args to parameters

### DIFF
--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -198,6 +198,9 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
     - name: SENTRY_RELEASE
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS_FILE


### PR DESCRIPTION
This readds buildargs to the build-container step. It was improperly removed