### PR TITLE
feat(ci): Tag images with short/long Git sha

### DIFF
--- a/pipelines/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta.yaml
@@ -542,8 +542,8 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: ADDITIONAL_TAGS
       value:
-        - "$(tasks.clone-repository.results.commit)"
-        - "$(tasks.clone-repository.results.short-commit)"
+      - "$(tasks.clone-repository.results.commit)"
+      - "$(tasks.clone-repository.results.short-commit)"
     runAfter:
     - build-image-index
     taskRef:

--- a/pipelines/docker-build-run-unit-tests-dynamic-env.yaml
+++ b/pipelines/docker-build-run-unit-tests-dynamic-env.yaml
@@ -564,8 +564,8 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: ADDITIONAL_TAGS
       value:
-        - "$(tasks.clone-repository.results.commit)"
-        - "$(tasks.clone-repository.results.short-commit)"
+      - "$(tasks.clone-repository.results.commit)"
+      - "$(tasks.clone-repository.results.short-commit)"
     runAfter:
     - build-image-index
     taskRef:

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -551,8 +551,8 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: ADDITIONAL_TAGS
       value:
-        - "$(tasks.clone-repository.results.commit)"
-        - "$(tasks.clone-repository.results.short-commit)"
+      - "$(tasks.clone-repository.results.commit)"
+      - "$(tasks.clone-repository.results.short-commit)"
     runAfter:
     - build-image-index
     taskRef:


### PR DESCRIPTION
When images are built and pushed to redhat-user-workloads quay repository, only git long sha hashes are used as image tags. Default configuration in App-sre is using short_git_sha as tags and therefore bonfire/tekton tests will not be able to find such tags and deploy containers from these images. This change should automatically tag all our images with short/long  git hashes. Releases to quay prod repos are controlled via RPAs, where both short and long git sha hashes are already configured as tags. 