### PR TITLE
fix(pipelines): fix workspace-setup execution in docker-build-run-all-tests-v2

### DIFF
--- a/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml
+++ b/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml
@@ -710,7 +710,7 @@ spec:
         script: |
           #!/bin/bash
           if [ -n "$(params.WORKSPACE_SETUP_SCRIPT)" ]; then
-            $(params.WORKSPACE_SETUP_SCRIPT)
+            bash -c "$(params.WORKSPACE_SETUP_SCRIPT)"
           else
             echo "No workspace setup script provided, skipping..."
           fi


### PR DESCRIPTION

# summary

fix syntax error in workspace-setup step, occurring when `WORKSPACE_SETUP_SCRIPT` parameter is empty.


# details

when _docker-build-run-all-tests-v2_ is used as a remote pipeline, and no `WORKSPACE_SETUP_SCRIPT` parameter is passed, the parameter value will be empty (defaults to an empty string).

upon running, this will cause an error in the [wrapper script][2].  
here's the wrapper script, as interpreted with an empty value, to simulate the bug:

```
#!/bin/bash
if [ -n "" ]; then
  
else
  echo "No workspace setup script provided, skipping..."
fi
```

... which will output this error:

```
$ ./test.sh
./test.sh: line 4: syntax error near unexpected token `else'
./test.sh: line 4: `else'
```

to fix this, i've wrapped the script execution with `bash -c ""`.

---
<br />

that error was found during an update from v1 to v2 in a consuming pipeline (see [this PR commit][1], and the [failing check][3] in uhc-portal repo).



[1]: https://github.com/RedHatInsights/uhc-portal/pull/444/changes/b940264d972e2880b80aeb28a14212291fecff9f
[2]: https://github.com/RedHatInsights/konflux-pipelines/blob/4d09ace9b7c5d1bdc1013aa302e46fe5c5a98925/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml#L711-L716
[3]: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/ocm-ui-tenant/applications/ocm-ui/pipelineruns/uhc-portal-on-pull-request-qrb5p/logs?task=run-unit-tests
