### PR TITLE
RHCLOUD-47105: fix: default to microsoft playwright image

### DIFF
--- a/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml
+++ b/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml
@@ -143,7 +143,7 @@ spec:
   - description: Playwright image to use for testing
     name: e2e-playwright-image
     type: string
-    default: "quay.io/btweed/playwright_e2e:latest"
+    default: "mcr.microsoft.com/playwright:v1.59.0-noble"
   - description: Frontend proxy image
     name: e2e-proxy-image
     type: string

--- a/pipelines/platform-ui/docker-build-run-all-tests.yaml
+++ b/pipelines/platform-ui/docker-build-run-all-tests.yaml
@@ -134,7 +134,7 @@ spec:
   - description: Playwright image to use for testing
     name: e2e-playwright-image
     type: string
-    default: "quay.io/btweed/playwright_e2e:latest"
+    default: "mcr.microsoft.com/playwright:v1.59.0-noble"
   - description: Frontend proxy image
     name: e2e-proxy-image
     type: string


### PR DESCRIPTION
The default playwright image parameter in the pipeline definition should have been an official image, not a custom-built one.

Tested here for v1: https://github.com/RedHatInsights/frontend-starter-app/pull/770
Tested here for v2: https://github.com/RedHatInsights/frontend-starter-app/pull/760