### PR TITLE
fix: unset GODEBUG in run-application sidecar to prevent Caddy panic

### DIFF
--- a/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml
+++ b/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml
@@ -899,6 +899,8 @@ spec:
         args:
         - $(params.run-app-script)
         env:
+        - name: GODEBUG
+          value: ""
         - name: HCC_ENV_URL
           value: $(params.HCC_ENV_URL)
         securityContext:

--- a/pipelines/platform-ui/docker-build-run-all-tests.yaml
+++ b/pipelines/platform-ui/docker-build-run-all-tests.yaml
@@ -874,6 +874,8 @@ spec:
         args:
         - $(params.run-app-script)
         env:
+        - name: GODEBUG
+          value: ""
         - name: HCC_ENV_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Problem
Frontend repositories using the shared test pipelines are experiencing CI/CD failures with Caddy panicking at startup:

```
panic: fips140: unknown GODEBUG setting fips140=auto
```

## Root Cause
The `caddy-ubi:latest` image was recently rebuilt with a newer UBI9 base that sets `GODEBUG=fips140=auto` for FIPS 140-3 compliance. However, the Caddy binary was compiled with Go <1.22, which doesn't recognize this setting.

## Solution
Unset `GODEBUG` in the `run-application` sidecar environment to allow Caddy to run normally. Caddy doesn't need FIPS mode for serving static files.

## Files Changed
- `pipelines/platform-ui/docker-build-run-all-tests.yaml`
- `pipelines/platform-ui/docker-build-run-all-tests-v2.yaml`

## Impact
This fix prevents pipeline failures across all frontend repositories using these shared pipeline definitions.

## Testing
Tested in learning-resources repository where the workaround (unsetting GODEBUG in run-app-script) resolved the issue.

## Related
- insights-frontend-builder-common Dockerfile: https://github.com/RedHatInsights/insights-frontend-builder-common/blob/main/Dockerfile#L83
- Go FIPS 140-3 docs: https://go.dev/doc/security/fips140