### PR TITLE
feat(renovate): use official postTask for RPM refresh and set recreate to always

### DIFF
--- a/renovate/foreman_satellite/renovate.json
+++ b/renovate/foreman_satellite/renovate.json
@@ -33,8 +33,14 @@
       "groupName": "image-and-rpm-updates",
       "enabled": true,
       "postUpgradeTasks": {
-        "commands": ["rpm-lockfile-prototype rpms.in.yaml"],
-        "fileFilters": ["**/rpms.lock.yaml"]
+        "commands": [
+          "refresh-rpm-lockfiles -f \"$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\""
+        ],
+        "fileFilters": [
+          "**/rpms.lock.yaml"
+        ],
+        "executionMode": "branch",
+        "dataFileTemplate": "[{{#each upgrades}}{\"packageFile\": \"{{{packageFile}}}\"}{{#unless @last}},{{\/unless}}{{\/each}}]"
       },
       "schedule": ["at any time"],
       "automerge": true,

--- a/renovate/foreman_satellite/renovate.json
+++ b/renovate/foreman_satellite/renovate.json
@@ -44,7 +44,8 @@
       },
       "schedule": ["at any time"],
       "automerge": true,
-      "autoApprove": true
+      "autoApprove": true,
+      "recreateWhen": "always"
     },
     {
       "matchBaseBranches": ["/^foreman-.*$/", "/^SATELLITE-.*$/"],


### PR DESCRIPTION
* use official postTask for rpm refresh https://github.com/konflux-ci/refresh-rpm-lockfiles#manual
* set recreate to always for dockerfile manager to fix an issue of Renovate not automerging PRs, for the image-and-rpm-updates group

RHINENG-25950